### PR TITLE
load MetaCPAN::Util in example scripts

### DIFF
--- a/scripts/author/1-fetch-single-author-es.pl
+++ b/scripts/author/1-fetch-single-author-es.pl
@@ -4,15 +4,11 @@ use strict;
 use warnings;
 
 use Data::Printer;
-use Search::Elasticsearch;
 
-my $es = Search::Elasticsearch->new(
-    cxn_pool => 'Static::NoPing',
-    nodes    => 'fastapi.metacpan.org',
-    trace_to => 'Stdout',
-);
+use lib './lib';
+use MetaCPAN::Util qw( es );
 
-my $author = $es->get(
+my $author = es->get(
     index => 'cpan',
     type  => 'author',
     id    => 'MSTROUT',

--- a/scripts/author/1b-scroll-all-authors-es.pl
+++ b/scripts/author/1b-scroll-all-authors-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $scroller = es()->scroll_helper(

--- a/scripts/author/1c-scroll-all-authors-with-twitter-es.pl
+++ b/scripts/author/1c-scroll-all-authors-with-twitter-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $scroller = es()->scroll_helper(

--- a/scripts/author/2-twitter-or-github-es.pl
+++ b/scripts/author/2-twitter-or-github-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use feature qw( say );
 
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $scroller = es()->scroll_helper(

--- a/scripts/distribution/1-bugs-for-dist-es.pl
+++ b/scripts/distribution/1-bugs-for-dist-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $dist = es()->get(

--- a/scripts/favorite/1-last-50-favorited-dists-es.pl
+++ b/scripts/favorite/1-last-50-favorited-dists-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $faves = es()->search(

--- a/scripts/favorite/1a-last-100-favorited-dists-by-user-es.pl
+++ b/scripts/favorite/1a-last-100-favorited-dists-by-user-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $id = shift @ARGV;

--- a/scripts/favorite/2-favorites-previous-month-es.pl
+++ b/scripts/favorite/2-favorites-previous-month-es.pl
@@ -5,6 +5,7 @@ use warnings;
 
 use Data::Printer;
 use DateTime;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $now = DateTime->now;

--- a/scripts/favorite/3-leaderboard-es.pl
+++ b/scripts/favorite/3-leaderboard-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $faves = es()->search(

--- a/scripts/favorite/4-leaderboard-previous-month-es.pl
+++ b/scripts/favorite/4-leaderboard-previous-month-es.pl
@@ -5,6 +5,7 @@ use warnings;
 
 use Data::Printer;
 use DateTime;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $now = DateTime->now;

--- a/scripts/favorite/5-plus-plus-your-favorites-es.pl
+++ b/scripts/favorite/5-plus-plus-your-favorites-es.pl
@@ -6,6 +6,7 @@ use warnings;
 use Data::Printer;
 use HTTP::Tiny ();
 use JSON::MaybeXS qw( encode_json );
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $token   = shift @ARGV;

--- a/scripts/favorite/6-list-plussers-by-module.pl
+++ b/scripts/favorite/6-list-plussers-by-module.pl
@@ -5,6 +5,7 @@ use warnings;
 use feature qw( say );
 
 use MetaCPAN::Client;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 binmode( STDOUT, ":utf8" );

--- a/scripts/file/1-get-files-in-dist-es.pl
+++ b/scripts/file/1-get-files-in-dist-es.pl
@@ -5,6 +5,7 @@ use warnings;
 use feature qw( say );
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $files = es()->search(

--- a/scripts/file/2-get-dists-with-cpanfile.pl
+++ b/scripts/file/2-get-dists-with-cpanfile.pl
@@ -5,6 +5,7 @@ use warnings;
 use feature qw( say );
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $files = es()->search(

--- a/scripts/file/3-find-files-in-top-level-by-name.pl
+++ b/scripts/file/3-find-files-in-top-level-by-name.pl
@@ -5,6 +5,7 @@ use warnings;
 use feature qw( say );
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $files = es()->search(

--- a/scripts/file/4-main-search.pl
+++ b/scripts/file/4-main-search.pl
@@ -5,6 +5,7 @@ use warnings;
 
 use Data::Printer;
 use JSON::MaybeXS qw( decode_json );
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $search_term = shift @ARGV || 'HTML-Re';

--- a/scripts/module/1-fetch-single-module-es.pl
+++ b/scripts/module/1-fetch-single-module-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $module = es()->get(

--- a/scripts/release/1-pkg2url-es.pl
+++ b/scripts/release/1-pkg2url-es.pl
@@ -4,15 +4,10 @@ use strict;
 use warnings;
 use feature qw( say );
 
-use Search::Elasticsearch;
+use lib './lib';
+use MetaCPAN::Util qw( es );
 
-my $es = Search::Elasticsearch->new(
-    cxn_pool => 'Static::NoPing',
-    nodes    => 'https://fastapi.metacpan.org',
-    trace_to => 'Stdout',
-);
-
-my $release = $es->search(
+my $release = es->search(
     index => 'cpan',
     type  => 'release',
     body  => {

--- a/scripts/release/1a-module2url-es.pl
+++ b/scripts/release/1a-module2url-es.pl
@@ -6,13 +6,10 @@ use feature qw( say );
 
 use Search::Elasticsearch;
 
-my $es = Search::Elasticsearch->new(
-    cxn_pool => 'Static::NoPing',
-    nodes    => 'https://fastapi.metacpan.org',
-    trace_to => 'Stdout',
-);
+use lib './lib';
+use MetaCPAN::Util qw( es );
 
-my $module = $es->search(
+my $module = es->search(
     index => 'cpan',
     type  => 'file',
     body  => {
@@ -29,7 +26,7 @@ my $module = $es->search(
 
 my $release_name = $module->{hits}{hits}[0]{_source}{release};
 
-my $release = $es->search(
+my $release = es->search(
     index => 'cpan',
     type  => 'release',
     body  => {

--- a/scripts/release/2-author-upload-leaderboard-es.pl
+++ b/scripts/release/2-author-upload-leaderboard-es.pl
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 
 use Data::Printer;
+
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $uploads = es()->search(

--- a/scripts/release/3-author-uploads-one-author-es.pl
+++ b/scripts/release/3-author-uploads-one-author-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use feature qw( say );
 
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $uploads = es()->search(

--- a/scripts/release/4-latest-release-versions-es.pl
+++ b/scripts/release/4-latest-release-versions-es.pl
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 
 use Data::Printer;
+
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $latest = es()->search(

--- a/scripts/release/4a-latest-release-versions-bool-filter-es.pl
+++ b/scripts/release/4a-latest-release-versions-bool-filter-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $latest = es()->search(

--- a/scripts/release/5-latest-releases-by-author-es.pl
+++ b/scripts/release/5-latest-releases-by-author-es.pl
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 
 use Data::Printer;
+
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $author = shift @ARGV;

--- a/scripts/release/6-latest-releases-with-git-repo-es.pl
+++ b/scripts/release/6-latest-releases-with-git-repo-es.pl
@@ -5,6 +5,7 @@ use warnings;
 use feature qw( say );
 
 use Data::Printer;
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my @must = (

--- a/scripts/release/7-all-releases-es.pl
+++ b/scripts/release/7-all-releases-es.pl
@@ -5,6 +5,8 @@ use warnings;
 use feature qw( say );
 
 use Data::Printer;
+
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $scroller = es()->scroll_helper(

--- a/scripts/release/8-all-releases-by-author-es.pl
+++ b/scripts/release/8-all-releases-by-author-es.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use feature qw( say );
 
+use lib './lib';
 use MetaCPAN::Util qw( es );
 
 my $uploads = es()->search(


### PR DESCRIPTION
1. added `use lib './lib'` before any loading of MetaCPAN::Util.
2. converted some (older?) cases where `es` object was created directly from S::Es to using it as well.